### PR TITLE
Accept alternate timestamps

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -62,9 +62,10 @@ def yield_credit_infos(fname: str, show_diners_rewards: bool):
     
     res = tabula.read_pdf(fname ,pages='all', stream=True)
     def try_transaction(line):
-        transaction_date = line[0]
+        transaction_date = str(line[0]).replace("null ", "")
         amount = line[-1]
         details = line[1]
+
         transaction_date = try_parse_date(transaction_date)
         if transaction_date is None:
             # If start of line is not Date skip,

--- a/parser.py
+++ b/parser.py
@@ -35,6 +35,7 @@ class TransactionWithRewards(NamedTuple):
 
 
 _DATE_FORMAT = "%d/%m/%Y"
+_DATE_FORMAT_ALT = "%d/%m/%Y %H:%M:%S"
 
 # Convert Amount to Number
 def try_sanitize_amount(amnts):
@@ -49,7 +50,12 @@ def try_parse_date(ds: str):
     try:
         return datetime.strptime(ds, _DATE_FORMAT)
     except:
-        return None
+        try:
+            return datetime.strptime(ds, _DATE_FORMAT_ALT)
+        except:
+            return None
+    return None
+
 
 # parses credit card statement
 def yield_credit_infos(fname: str, show_diners_rewards: bool):


### PR DESCRIPTION
Some entries in the credit card statement have a different timestamp (which includes hours, minutes & seconds). (most domestic entries in my CC statement are of this format).

Some entries have a "null " substring prefixed to their timestamp (have seen this for a DoorDash international order).

This PR just accepts these entries as well. 